### PR TITLE
Fix: Export storeAccessTokenInMemory and other utils from api.js

### DIFF
--- a/extra_smart/src/api.js
+++ b/extra_smart/src/api.js
@@ -128,4 +128,4 @@ export default api;
 // Export the new token management functions if they need to be used outside this module,
 // otherwise, keep them internal. For now, `logout` is the main public function.
 // `setAccessToken` and `getAccessToken` are removed as per plan.
-export { logout };
+export { logout, storeAccessTokenInMemory, refreshAccessToken, getAccessTokenFromMemory, isTokenExpired };


### PR DESCRIPTION
Ensures that `storeAccessTokenInMemory`, `refreshAccessToken`, `getAccessTokenFromMemory`, and `isTokenExpired` are exported from `extra_smart/src/api.js`.

This fixes a build error where `storeAccessTokenInMemory` was not found when imported by `AuthLogin.jsx` during Vercel deployment.